### PR TITLE
fix wrong transaction name in errorwrapping

### DIFF
--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionMatriculation.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionMatriculation.scala
@@ -17,7 +17,7 @@ case class ConnectionMatriculation(username: String, channel: String, chaincode:
 
   override def addEntriesToMatriculationData(matriculationId: String, subjectMatriculationList: String): String =
     wrapTransactionResult(
-      "addEntryToMatriculationData",
+      "addEntriesToMatriculationData",
       this.internalSubmitTransaction(false, "addEntriesToMatriculationData", matriculationId, subjectMatriculationList)
     )
 

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/MatriculationErrorTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/MatriculationErrorTests.scala
@@ -108,7 +108,7 @@ class MatriculationErrorTests extends TestBase {
           id,
           TestDataMatriculation.getSubjectMatriculationList(fieldOfStudy, semester)
         ))
-        result.transactionId should ===("addEntryToMatriculationData")
+        result.transactionId should ===("addEntriesToMatriculationData")
       }
       "throw TransactionException for empty matriculationId " in {
         val id = ""
@@ -118,7 +118,7 @@ class MatriculationErrorTests extends TestBase {
           id,
           TestDataMatriculation.getSubjectMatriculationList(fieldOfStudy, semester)
         ))
-        result.transactionId should ===("addEntryToMatriculationData")
+        result.transactionId should ===("addEntriesToMatriculationData")
       }
       "throw TransactionException for malformed semester Entry " in {
         val id = "001"
@@ -128,7 +128,7 @@ class MatriculationErrorTests extends TestBase {
           id,
           TestDataMatriculation.getSubjectMatriculationList(fieldOfStudy, semester)
         ))
-        result.transactionId should ===("addEntryToMatriculationData")
+        result.transactionId should ===("addEntriesToMatriculationData")
       }
       "throw TransactionException for empty semester Entry " in {
         val id = "001"
@@ -138,7 +138,7 @@ class MatriculationErrorTests extends TestBase {
           id,
           TestDataMatriculation.getSubjectMatriculationList(fieldOfStudy, semester)
         ))
-        result.transactionId should ===("addEntryToMatriculationData")
+        result.transactionId should ===("addEntriesToMatriculationData")
       }
       "throw TransactionException for empty fieldOfStudy Entry " in {
         val id = "001"
@@ -148,7 +148,7 @@ class MatriculationErrorTests extends TestBase {
           id,
           TestDataMatriculation.getSubjectMatriculationList(fieldOfStudy, semester)
         ))
-        result.transactionId should ===("addEntryToMatriculationData")
+        result.transactionId should ===("addEntriesToMatriculationData")
       }
     }
   }


### PR DESCRIPTION
### Reason for this PR
- using wrong/old api-transaction-name

### Changes in this PR
- change api-transaction-name to plural/new
