### PR TITLE
Remove final preventing mocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# <a id="v0.11.3" />[v0.11.3](https://github.com/upb-uc4/hyperledger_api/compare/v0.11.2...0.11.3) (2020-10-29)
+
+## Refactor
+
+- remove ```final``` from ```submitSignedTransaction``` to allow for mocking
+
 # <a id="v0.11.2" />[v0.11.2 - WIP](https://github.com/upb-uc4/hyperledger_api/compare/v0.11.0...develop) (TBD)
 
 ## Feature

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
@@ -76,7 +76,7 @@ trait ConnectionTrait extends AutoCloseable {
     proposal.toByteArray
   }
 
-  final def submitSignedProposal(proposalBytes: Array[Byte], signature: ByteString): String = {
+  def submitSignedProposal(proposalBytes: Array[Byte], signature: ByteString): String = {
     val proposal: Proposal = Proposal.parseFrom(proposalBytes)
 
     val (transaction, context, signedProposal) = this.createProposal(proposal, signature)


### PR DESCRIPTION
### Reason for this PR
- final on submitSignedTransaction prevents mocking and shall hence be removed

### Changes in this PR
- remove final
