### PR TITLE
remove final from getChaincodeVersion

### DIFF
--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
@@ -40,7 +40,7 @@ trait ConnectionTrait extends AutoCloseable {
     *
     * @return String containing versionInfo
     */
-  final def getChaincodeVersion: String = wrapEvaluateTransaction("getVersion")
+  def getChaincodeVersion: String = wrapEvaluateTransaction("getVersion")
 
   private def approveTransaction(transactionName: String, params: String*) = {
     // setup approvalConnection and


### PR DESCRIPTION
### Reason for this PR
- final prevents us to mock this method

### Changes in this PR
- removed final