### PR TITLE
Feature/temper with connection include new submission bug

### DIFF
--- a/.github/workflows/production_network_test.yml
+++ b/.github/workflows/production_network_test.yml
@@ -47,7 +47,7 @@ jobs:
 
   DeployAndTestProductionNetwork:
     env:
-      TEST_SET: "*AdmissionTests *ExaminationRegulationAccessTests *ExaminationRegulationErrorTests *CertificateAccessTests *CertificateErrorTests *MatriculationErrorTests *MatriculationAccessTests *VersionAccessTests *UserManagementTests *InternalManagerTests *UnsignedTransactionTests *ApprovalTests"
+      TEST_SET: "*UnsignedTransactionTests"
       CHAINCODE_TARGET: ""
 
     runs-on: ubuntu-latest

--- a/.github/workflows/production_network_test.yml
+++ b/.github/workflows/production_network_test.yml
@@ -47,7 +47,7 @@ jobs:
 
   DeployAndTestProductionNetwork:
     env:
-      TEST_SET: "*UnsignedTransactionTests"
+      TEST_SET: "*AdmissionTests *ExaminationRegulationAccessTests *ExaminationRegulationErrorTests *CertificateAccessTests *CertificateErrorTests *MatriculationErrorTests *MatriculationAccessTests *VersionAccessTests *UserManagementTests *InternalManagerTests *UnsignedTransactionTests *ApprovalTests"
       CHAINCODE_TARGET: ""
 
     runs-on: ubuntu-latest

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionAdmission.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionAdmission.scala
@@ -7,17 +7,17 @@ import de.upb.cs.uc4.hyperledger.connections.traits.ConnectionAdmissionTrait
 protected[hyperledger] case class ConnectionAdmission(username: String, channel: String, chaincode: String, walletPath: Path, networkDescriptionPath: Path)
   extends ConnectionAdmissionTrait {
 
-  override def getProposalAddAdmission(certificate: String, affiliation: String, admission: String): (String, Array[Byte]) = {
+  override def getProposalAddAdmission(certificate: String, affiliation: String = AFFILITATION, admission: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addAdmission", admission)
   }
 
-  override def getProposalDropAdmission(certificate: String, affiliation: String, admissionId: String): (String, Array[Byte]) = {
+  override def getProposalDropAdmission(certificate: String, affiliation: String = AFFILITATION, admissionId: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "dropAdmission", admissionId)
   }
 
-  override def getProposalGetAdmission(certificate: String, affiliation: String, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): (String, Array[Byte]) = {
+  override def getProposalGetAdmission(certificate: String, affiliation: String = AFFILITATION, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getAdmissions", enrollmentId, courseId, moduleId)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionAdmission.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionAdmission.scala
@@ -7,17 +7,17 @@ import de.upb.cs.uc4.hyperledger.connections.traits.ConnectionAdmissionTrait
 protected[hyperledger] case class ConnectionAdmission(username: String, channel: String, chaincode: String, walletPath: Path, networkDescriptionPath: Path)
   extends ConnectionAdmissionTrait {
 
-  override def getProposalAddAdmission(certificate: String, affiliation: String, admission: String): Array[Byte] = {
+  override def getProposalAddAdmission(certificate: String, affiliation: String, admission: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addAdmission", admission)
   }
 
-  override def getProposalDropAdmission(certificate: String, affiliation: String, admissionId: String): Array[Byte] = {
+  override def getProposalDropAdmission(certificate: String, affiliation: String, admissionId: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "dropAdmission", admissionId)
   }
 
-  override def getProposalGetAdmission(certificate: String, affiliation: String, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): Array[Byte] = {
+  override def getProposalGetAdmission(certificate: String, affiliation: String, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getAdmissions", enrollmentId, courseId, moduleId)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionCertificate.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionCertificate.scala
@@ -8,17 +8,17 @@ import de.upb.cs.uc4.hyperledger.utilities.helper.Logger
 case class ConnectionCertificate(username: String, channel: String, chaincode: String, walletPath: Path, networkDescriptionPath: Path)
   extends ConnectionCertificateTrait {
 
-  override def getProposalAddCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte]) = {
+  override def getProposalAddCertificate(certificate: String, affiliation: String = AFFILITATION, enrollmentID: String, newCertificate: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addCertificate", enrollmentID, newCertificate)
   }
 
-  override def getProposalUpdateCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte]) = {
+  override def getProposalUpdateCertificate(certificate: String, affiliation: String = AFFILITATION, enrollmentID: String, newCertificate: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "updateCertificate", enrollmentID, newCertificate)
   }
 
-  override def getProposalGetCertificate(certificate: String, affiliation: String, enrollmentID: String): (String, Array[Byte]) = {
+  override def getProposalGetCertificate(certificate: String, affiliation: String = AFFILITATION, enrollmentID: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getCertificate", enrollmentID)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionCertificate.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionCertificate.scala
@@ -8,17 +8,17 @@ import de.upb.cs.uc4.hyperledger.utilities.helper.Logger
 case class ConnectionCertificate(username: String, channel: String, chaincode: String, walletPath: Path, networkDescriptionPath: Path)
   extends ConnectionCertificateTrait {
 
-  override def getProposalAddCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): Array[Byte] = {
+  override def getProposalAddCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addCertificate", enrollmentID, newCertificate)
   }
 
-  override def getProposalUpdateCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): Array[Byte] = {
+  override def getProposalUpdateCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "updateCertificate", enrollmentID, newCertificate)
   }
 
-  override def getProposalGetCertificate(certificate: String, affiliation: String, enrollmentID: String): Array[Byte] = {
+  override def getProposalGetCertificate(certificate: String, affiliation: String, enrollmentID: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getCertificate", enrollmentID)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionExaminationRegulation.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionExaminationRegulation.scala
@@ -7,17 +7,17 @@ import de.upb.cs.uc4.hyperledger.connections.traits.ConnectionExaminationRegulat
 case class ConnectionExaminationRegulation(username: String, channel: String, chaincode: String, walletPath: Path, networkDescriptionPath: Path)
   extends ConnectionExaminationRegulationTrait {
 
-  def getProposalAddExaminationRegulation(certificate: String, affiliation: String, examinationRegulation: String): (String, Array[Byte]) = {
+  def getProposalAddExaminationRegulation(certificate: String, affiliation: String = AFFILITATION, examinationRegulation: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addExaminationRegulation", examinationRegulation)
   }
 
-  def getProposalGetExaminationRegulations(certificate: String, affiliation: String, namesList: String): (String, Array[Byte]) = {
+  def getProposalGetExaminationRegulations(certificate: String, affiliation: String = AFFILITATION, namesList: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getExaminationRegulations", namesList)
   }
 
-  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String, name: String): (String, Array[Byte]) = {
+  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String = AFFILITATION, name: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "closeExaminationRegulation", name)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionExaminationRegulation.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionExaminationRegulation.scala
@@ -7,17 +7,17 @@ import de.upb.cs.uc4.hyperledger.connections.traits.ConnectionExaminationRegulat
 case class ConnectionExaminationRegulation(username: String, channel: String, chaincode: String, walletPath: Path, networkDescriptionPath: Path)
   extends ConnectionExaminationRegulationTrait {
 
-  def getProposalAddExaminationRegulation(certificate: String, affiliation: String, examinationRegulation: String): Array[Byte] = {
+  def getProposalAddExaminationRegulation(certificate: String, affiliation: String, examinationRegulation: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addExaminationRegulation", examinationRegulation)
   }
 
-  def getProposalGetExaminationRegulations(certificate: String, affiliation: String, namesList: String): Array[Byte] = {
+  def getProposalGetExaminationRegulations(certificate: String, affiliation: String, namesList: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getExaminationRegulations", namesList)
   }
 
-  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String, name: String): Array[Byte] = {
+  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String, name: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "closeExaminationRegulation", name)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionMatriculation.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionMatriculation.scala
@@ -8,22 +8,22 @@ case class ConnectionMatriculation(username: String, channel: String, chaincode:
   extends ConnectionMatriculationTrait {
   final override val contractName: String = "UC4.MatriculationData"
 
-  def getProposalAddMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): Array[Byte] = {
+  def getProposalAddMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addMatriculationData", jSonMatriculationData)
   }
 
-  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String, enrollmentId: String, subjectMatriculationList: String): Array[Byte] = {
+  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String, enrollmentId: String, subjectMatriculationList: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addEntriesToMatriculationData", enrollmentId: String, subjectMatriculationList: String)
   }
 
-  def getProposalUpdateMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): Array[Byte] = {
+  def getProposalUpdateMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "updateMatriculationData", jSonMatriculationData)
   }
 
-  def getProposalGetMatriculationData(certificate: String, affiliation: String, enrollmentId: String): Array[Byte] = {
+  def getProposalGetMatriculationData(certificate: String, affiliation: String, enrollmentId: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getMatriculationData", enrollmentId)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionMatriculation.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionMatriculation.scala
@@ -8,22 +8,22 @@ case class ConnectionMatriculation(username: String, channel: String, chaincode:
   extends ConnectionMatriculationTrait {
   final override val contractName: String = "UC4.MatriculationData"
 
-  def getProposalAddMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte]) = {
+  def getProposalAddMatriculationData(certificate: String, affiliation: String = AFFILITATION, jSonMatriculationData: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addMatriculationData", jSonMatriculationData)
   }
 
-  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String, enrollmentId: String, subjectMatriculationList: String): (String, Array[Byte]) = {
+  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String = AFFILITATION, enrollmentId: String, subjectMatriculationList: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "addEntriesToMatriculationData", enrollmentId: String, subjectMatriculationList: String)
   }
 
-  def getProposalUpdateMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte]) = {
+  def getProposalUpdateMatriculationData(certificate: String, affiliation: String = AFFILITATION, jSonMatriculationData: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "updateMatriculationData", jSonMatriculationData)
   }
 
-  def getProposalGetMatriculationData(certificate: String, affiliation: String, enrollmentId: String): (String, Array[Byte]) = {
+  def getProposalGetMatriculationData(certificate: String, affiliation: String = AFFILITATION, enrollmentId: String): (String, Array[Byte]) = {
     // TODO: add error handling
     internalGetUnsignedProposal(certificate, affiliation, "getMatriculationData", enrollmentId)
   }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionAdmissionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionAdmissionTrait.scala
@@ -15,7 +15,7 @@ protected[hyperledger] trait ConnectionAdmissionTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddAdmission(certificate: String, affiliation: String, admission: String): Array[Byte]
+  def getProposalAddAdmission(certificate: String, affiliation: String, admission: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "dropAdmission" query as current user (admin).
@@ -27,7 +27,7 @@ protected[hyperledger] trait ConnectionAdmissionTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalDropAdmission(certificate: String, affiliation: String, admissionId: String): Array[Byte]
+  def getProposalDropAdmission(certificate: String, affiliation: String, admissionId: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "getAdmissions" query as current user (admin).
@@ -41,7 +41,7 @@ protected[hyperledger] trait ConnectionAdmissionTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetAdmission(certificate: String, affiliation: String, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): Array[Byte]
+  def getProposalGetAdmission(certificate: String, affiliation: String, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): (String, Array[Byte])
 
   /** Submits the "addAdmission" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionAdmissionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionAdmissionTrait.scala
@@ -15,7 +15,7 @@ trait ConnectionAdmissionTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddAdmission(certificate: String, affiliation: String, admission: String): (String, Array[Byte])
+  def getProposalAddAdmission(certificate: String, affiliation: String = AFFILITATION, admission: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "dropAdmission" query as current user (admin).
@@ -27,7 +27,7 @@ trait ConnectionAdmissionTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalDropAdmission(certificate: String, affiliation: String, admissionId: String): (String, Array[Byte])
+  def getProposalDropAdmission(certificate: String, affiliation: String = AFFILITATION, admissionId: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "getAdmissions" query as current user (admin).
@@ -41,7 +41,7 @@ trait ConnectionAdmissionTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetAdmission(certificate: String, affiliation: String, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): (String, Array[Byte])
+  def getProposalGetAdmission(certificate: String, affiliation: String = AFFILITATION, enrollmentId: String = "", courseId: String = "", moduleId: String = ""): (String, Array[Byte])
 
   /** Submits the "addAdmission" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionCertificateTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionCertificateTrait.scala
@@ -16,7 +16,7 @@ trait ConnectionCertificateTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte])
+  def getProposalAddCertificate(certificate: String, affiliation: String = AFFILITATION, enrollmentID: String, newCertificate: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "updateCertificate" query as current user (admin).
@@ -29,7 +29,7 @@ trait ConnectionCertificateTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalUpdateCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte])
+  def getProposalUpdateCertificate(certificate: String, affiliation: String = AFFILITATION, enrollmentID: String, newCertificate: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "getCertificate" query as current user (admin).
@@ -41,7 +41,7 @@ trait ConnectionCertificateTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetCertificate(certificate: String, affiliation: String, enrollmentID: String): (String, Array[Byte])
+  def getProposalGetCertificate(certificate: String, affiliation: String = AFFILITATION, enrollmentID: String): (String, Array[Byte])
 
   /** Submits the "addCertificate" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionCertificateTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionCertificateTrait.scala
@@ -16,7 +16,7 @@ trait ConnectionCertificateTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): Array[Byte]
+  def getProposalAddCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "updateCertificate" query as current user (admin).
@@ -29,7 +29,7 @@ trait ConnectionCertificateTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalUpdateCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): Array[Byte]
+  def getProposalUpdateCertificate(certificate: String, affiliation: String, enrollmentID: String, newCertificate: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "getCertificate" query as current user (admin).
@@ -41,7 +41,7 @@ trait ConnectionCertificateTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetCertificate(certificate: String, affiliation: String, enrollmentID: String): Array[Byte]
+  def getProposalGetCertificate(certificate: String, affiliation: String, enrollmentID: String): (String, Array[Byte])
 
   /** Submits the "addCertificate" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionExaminationRegulationTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionExaminationRegulationTrait.scala
@@ -15,7 +15,7 @@ trait ConnectionExaminationRegulationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddExaminationRegulation(certificate: String, affiliation: String, examinationRegulation: String): Array[Byte]
+  def getProposalAddExaminationRegulation(certificate: String, affiliation: String, examinationRegulation: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits approval for the query as current user (admin).
@@ -28,7 +28,7 @@ trait ConnectionExaminationRegulationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetExaminationRegulations(certificate: String, affiliation: String, namesList: String): Array[Byte]
+  def getProposalGetExaminationRegulations(certificate: String, affiliation: String, namesList: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits approval for the query as current user (admin).
@@ -40,7 +40,7 @@ trait ConnectionExaminationRegulationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String, name: String): Array[Byte]
+  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String, name: String): (String, Array[Byte])
 
   /** Submits the "addExaminationRegulation" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionExaminationRegulationTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionExaminationRegulationTrait.scala
@@ -15,7 +15,7 @@ trait ConnectionExaminationRegulationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddExaminationRegulation(certificate: String, affiliation: String, examinationRegulation: String): (String, Array[Byte])
+  def getProposalAddExaminationRegulation(certificate: String, affiliation: String = AFFILITATION, examinationRegulation: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits approval for the query as current user (admin).
@@ -28,7 +28,7 @@ trait ConnectionExaminationRegulationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetExaminationRegulations(certificate: String, affiliation: String, namesList: String): (String, Array[Byte])
+  def getProposalGetExaminationRegulations(certificate: String, affiliation: String = AFFILITATION, namesList: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits approval for the query as current user (admin).
@@ -40,7 +40,7 @@ trait ConnectionExaminationRegulationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String, name: String): (String, Array[Byte])
+  def getProposalCloseExaminationRegulation(certificate: String, affiliation: String = AFFILITATION, name: String): (String, Array[Byte])
 
   /** Submits the "addExaminationRegulation" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionMatriculationTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionMatriculationTrait.scala
@@ -14,7 +14,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte])
+  def getProposalAddMatriculationData(certificate: String, affiliation: String = AFFILITATION, jSonMatriculationData: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "addEntriesToMatriculationData" query as current user (admin).
@@ -27,7 +27,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String, enrollmentId: String, subjectMatriculationList: String): (String, Array[Byte])
+  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String = AFFILITATION, enrollmentId: String, subjectMatriculationList: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "updateMatriculationData" query as current user (admin).
@@ -39,7 +39,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalUpdateMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte])
+  def getProposalUpdateMatriculationData(certificate: String, affiliation: String = AFFILITATION, jSonMatriculationData: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "getMatriculationData" query as current user (admin).
@@ -51,7 +51,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetMatriculationData(certificate: String, affiliation: String, enrollmentId: String): (String, Array[Byte])
+  def getProposalGetMatriculationData(certificate: String, affiliation: String = AFFILITATION, enrollmentId: String): (String, Array[Byte])
 
   /** Submits the "addMatriculationData" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionMatriculationTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionMatriculationTrait.scala
@@ -14,7 +14,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): Array[Byte]
+  def getProposalAddMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "addEntriesToMatriculationData" query as current user (admin).
@@ -27,7 +27,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String, enrollmentId: String, subjectMatriculationList: String): Array[Byte]
+  def getProposalAddEntriesToMatriculationData(certificate: String, affiliation: String, enrollmentId: String, subjectMatriculationList: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "updateMatriculationData" query as current user (admin).
@@ -39,7 +39,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalUpdateMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): Array[Byte]
+  def getProposalUpdateMatriculationData(certificate: String, affiliation: String, jSonMatriculationData: String): (String, Array[Byte])
 
   /** Retrieves a proposal for the designated query
     * Also submits the "getMatriculationData" query as current user (admin).
@@ -51,7 +51,7 @@ trait ConnectionMatriculationTrait extends ConnectionTrait {
     */
   @throws[HyperledgerExceptionTrait]
   @throws[TransactionExceptionTrait]
-  def getProposalGetMatriculationData(certificate: String, affiliation: String, enrollmentId: String): Array[Byte]
+  def getProposalGetMatriculationData(certificate: String, affiliation: String, enrollmentId: String): (String, Array[Byte])
 
   /** Submits the "addMatriculationData" query.
     *

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
@@ -23,6 +23,8 @@ import scala.jdk.CollectionConverters
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 trait ConnectionTrait extends AutoCloseable {
+  val AFFILITATION: String = "org1MSP"
+
   // regular info used to set up any connection
   val username: String
   val channel: String

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
@@ -127,7 +127,7 @@ trait ConnectionTrait extends AutoCloseable {
     transactionPayload.toByteArray
   }
 
-  def submitSignedTransaction(transactionBytes: Array[Byte], signature: Array[Byte]): String = {
+  def submitSignedTransaction(transactionBytes: Array[Byte], signature: Array[Byte]): (String, String) = {
     val transactionPayload: Payload = Payload.parseFrom(transactionBytes)
     val transactionId: String = TransactionHelper.getTransactionIdFromHeader(transactionPayload.getHeader)
     val (transactionName, params) = TransactionHelper.getParametersFromTransactionPayload(transactionPayload)
@@ -139,7 +139,7 @@ trait ConnectionTrait extends AutoCloseable {
     val realResult = internalSubmitRealTransactionFromApprovalProposal(params)
 
     // return both results
-    new Gson().toJson(Seq(approvalResult, realResult))
+    (approvalResult, realResult)
   }
 
   def internalSubmitRealTransactionFromApprovalProposal(params: Seq[String]): String = {

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/traits/ConnectionTrait.scala
@@ -17,6 +17,7 @@ import org.hyperledger.fabric.gateway.GatewayRuntimeException
 import org.hyperledger.fabric.protos.common.Common.Payload
 import org.hyperledger.fabric.protos.peer.ProposalPackage.{ Proposal, SignedProposal }
 import org.hyperledger.fabric.sdk._
+import org.hyperledger.fabric.sdk.transaction.TransactionContext
 
 import scala.jdk.CollectionConverters
 import scala.jdk.CollectionConverters.MapHasAsJava
@@ -43,14 +44,16 @@ trait ConnectionTrait extends AutoCloseable {
     */
   def getChaincodeVersion: String = wrapEvaluateTransaction("getVersion")
 
-  private def approveTransaction(transactionName: String, params: String*): Unit = {
+  private def approveTransaction(transactionName: String, params: String*): String = {
+    var approvalResult: String = ""
     // setup approvalConnection and
     // submit my approval to approvalContract
     val approvalConnectionObject = approvalConnection
     if (approvalConnectionObject.isDefined) {
-      approvalConnectionObject.get.approveTransaction(contractName, transactionName, params: _*)
+      approvalResult = approvalConnectionObject.get.approveTransaction(contractName, transactionName, params: _*)
       approvalConnectionObject.get.close()
     }
+    approvalResult
   }
 
   /** Wrapper for a submission transaction
@@ -88,15 +91,18 @@ trait ConnectionTrait extends AutoCloseable {
   }
 
   // TODO read affiliation from certificate
-  protected final def internalGetUnsignedProposal(certificate: String, affiliation: String, transactionName: String, params: String*): Array[Byte] = {
+  protected final def internalGetUnsignedProposal(certificate: String, affiliation: String, transactionName: String, params: String*): (String, Array[Byte]) = {
     // approve transaction as ADMIN managing the current connection
-    approveTransaction(transactionName, params: _*)
+    val approvalResult: String = approveTransaction(transactionName, params: _*)
 
     // prepare the approvalTransaction for the user.
     val fcnName: String = "UC4.Approval:approveTransaction"
     val args: Seq[String] = Seq(this.contractName).appended(transactionName).appended(new Gson().toJson(params.toArray))
     val proposal = TransactionHelper.getUnsignedProposalNew(certificate, affiliation, chaincode, channel, fcnName, networkDescriptionPath, args: _*)
-    proposal.toByteArray
+    val proposalBytes = proposal.toByteArray
+
+    // return both (approvalResult and proposal)
+    (approvalResult, proposalBytes)
   }
 
   def getUnsignedTransaction(proposalBytes: Array[Byte], signatureBytes: Array[Byte]): Array[Byte] = {
@@ -113,7 +119,7 @@ trait ConnectionTrait extends AutoCloseable {
     val transactionName = TransactionHelper.getTransactionNameFromProposal(transactionProposal)
     val transactionParams = TransactionHelper.getTransactionParamsFromProposal(transactionProposal)
     val transactionId = TransactionHelper.getTransactionIdFromProposal(transactionProposal)
-    val (_, ctx, _) = TransactionHelper.createTransactionInfo(this.approvalConnection.get.contract, transactionName, transactionParams.toArray, Some(transactionId))
+    val (_, ctx: TransactionContext, _) = TransactionHelper.createTransactionInfo(this.approvalConnection.get.contract, transactionName, transactionParams, Some(transactionId))
     val proposalResponses = ReflectionHelper.safeCallPrivateMethod(channelObj)("sendProposalToPeers")(peers, signedProposal, ctx).asInstanceOf[util.Collection[ProposalResponse]]
 
     val validResponses = ReflectionHelper.safeCallPrivateMethod(transaction)("validatePeerResponses")(proposalResponses).asInstanceOf[util.Collection[ProposalResponse]]
@@ -129,9 +135,10 @@ trait ConnectionTrait extends AutoCloseable {
     val response: Array[Byte] = TransactionHelper.sendTransaction(this, channel, ctx, this.gateway.getNetwork(channel).getChannel, ByteString.copyFrom(transactionBytes), signature, transactionId)
     val approvalResult = wrapTransactionResult(transactionName, response)
 
-    // TODO: test parse params to execute real transaction
-    //approvalResult
+    // execute real Transaction
     val realResult = internalSubmitRealTransactionFromApprovalProposal(params)
+
+    // return both results
     new Gson().toJson(Seq(approvalResult, realResult))
   }
 

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
@@ -81,7 +81,7 @@ class UnsignedTransactionTests extends TestBase {
         println("\n\n\n##########################\nMatriculationTestData:\n##########################\n\n" + testMatData)
 
         // get proposal
-        val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(Identities.toPemString(certificate), testAffiliation, testMatData)
+        val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(Identities.toPemString(certificate), jSonMatriculationData=testMatData)
         println("\n\n\n##########################\nProposal Bytes:\n##########################\n\n" + Base64.getEncoder.encodeToString(proposalBytes))
 
         // sign proposal with testUser privateKey

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
@@ -81,7 +81,7 @@ class UnsignedTransactionTests extends TestBase {
         println("\n\n\n##########################\nMatriculationTestData:\n##########################\n\n" + testMatData)
 
         // get proposal
-        val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(Identities.toPemString(certificate), jSonMatriculationData=testMatData)
+        val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(Identities.toPemString(certificate), jSonMatriculationData = testMatData)
         println("\n\n\n##########################\nProposal Bytes:\n##########################\n\n" + Base64.getEncoder.encodeToString(proposalBytes))
 
         // sign proposal with testUser privateKey


### PR DESCRIPTION
### Reason for this PR
- Lagom needs to store Unique "Operation" Identifiers. Meaning we have to relay the approvalResults to Lagom when the Operation-process starts.
- Refer to API change https://github.com/upb-uc4/api/pull/92

### Changes in this PR
- cleanup PR https://github.com/upb-uc4/hlf-api/pull/118
- ALWAYS RETURN APPROVAL-RESULT
