### PR TITLE
Feature/test print transaction info

### DIFF
--- a/.github/workflows/production_network_test.yml
+++ b/.github/workflows/production_network_test.yml
@@ -47,7 +47,7 @@ jobs:
 
   DeployAndTestProductionNetwork:
     env:
-      TEST_SET: "*AdmissionTests *ExaminationRegulationAccessTests *ExaminationRegulationErrorTests *CertificateAccessTests *CertificateErrorTests *MatriculationErrorTests *MatriculationAccessTests *VersionAccessTests *UserManagementTests *InternalManagerTests *UnsignedTransactionTests *ApprovalTests"
+      TEST_SET: "*UnsignedTransactionTests"
       CHAINCODE_TARGET: ""
 
     runs-on: ubuntu-latest

--- a/.github/workflows/production_network_test.yml
+++ b/.github/workflows/production_network_test.yml
@@ -47,7 +47,7 @@ jobs:
 
   DeployAndTestProductionNetwork:
     env:
-      TEST_SET: "*UnsignedTransactionTests"
+      TEST_SET: "*AdmissionTests *ExaminationRegulationAccessTests *ExaminationRegulationErrorTests *CertificateAccessTests *CertificateErrorTests *MatriculationErrorTests *MatriculationAccessTests *VersionAccessTests *UserManagementTests *InternalManagerTests *UnsignedTransactionTests *ApprovalTests"
       CHAINCODE_TARGET: ""
 
     runs-on: ubuntu-latest

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionApproval.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/connections/cases/ConnectionApproval.scala
@@ -11,12 +11,12 @@ protected[hyperledger] case class ConnectionApproval(username: String, channel: 
   override def approvalConnection: Option[ConnectionApprovalsTrait] = None
 
   override def approveTransaction(contractName: String, transactionName: String, params: String*): String = {
-    val transactionValues = TransactionHelper.getApprovalTransactionFromParameters(contractName, transactionName, params.toArray)
+    val transactionValues = TransactionHelper.getApprovalParameterList(contractName, transactionName, params.toArray)
     wrapSubmitTransaction(false, "approveTransaction", transactionValues: _*)
   }
 
   override def getApprovals(contractName: String, transactionName: String, params: String*): String = {
-    val transactionValues = TransactionHelper.getApprovalTransactionFromParameters(contractName, transactionName, params.toArray)
+    val transactionValues = TransactionHelper.getApprovalParameterList(contractName, transactionName, params.toArray)
     wrapEvaluateTransaction("getApprovals", transactionValues: _*)
   }
 }

--- a/src/main/scala/de/upb/cs/uc4/hyperledger/utilities/helper/TransactionHelper.scala
+++ b/src/main/scala/de/upb/cs/uc4/hyperledger/utilities/helper/TransactionHelper.scala
@@ -58,11 +58,9 @@ protected[hyperledger] object TransactionHelper {
     ChaincodeActionPayload.parseFrom(transaction.getActions(0).getPayload)
   }
 
-  def getApprovalTransactionFromParameters(contractName: String, transactionName: String, params: Array[String]): Seq[String] = {
+  def getApprovalParameterList(contractName: String, transactionName: String, params: Array[String]): Seq[String] = {
     val jsonParams = new Gson().toJson(params)
-    val info = List[String](contractName, transactionName, jsonParams)
-    Logger.info(s"PREPARE APPROVAL:: ${info.foldLeft("")((A, B) => A + "::" + B)}")
-    info
+    List[String](contractName, transactionName, jsonParams)
   }
 
   def createTransactionInfo(contract: ContractImpl, transactionName: String, params: Seq[String], transactionId: Option[String]): (TransactionImpl, TransactionContext, TransactionProposalRequest) = {

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/testBase/TestBase.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/testBase/TestBase.scala
@@ -43,7 +43,7 @@ class TestBase extends TestBaseTrait {
       EnrollmentManager.enroll(caURL, tlsCert, walletPath, enrollmentId, testUserPw, organisationId, channel, chaincode, networkDescriptionPath)
     }
     catch {
-      case _: Throwable =>
+      case e: Throwable => Logger.err(s"Register and Enroll test user '$enrollmentId' failed.", e)
     }
     val wallet: Wallet = WalletManager.getWallet(this.walletPath)
     wallet.get(enrollmentId).asInstanceOf[X509IdentityImpl]
@@ -65,7 +65,7 @@ class TestBase extends TestBaseTrait {
         EnrollmentManager.enroll(caURL, caCert, walletPath, enrollmentID, enrollmentSecret, organisationId, channel, chaincode, networkDescriptionPath)
       }
       catch {
-        case e: Exception => Logger.warn("Enrollment failed, maybe some other test already enrolled the admin: " + e.getMessage)
+        case e: Exception => Logger.warn("Admin Enrollment failed, maybe some other test already enrolled the admin: " + e.getMessage)
       }
     }
   }

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
@@ -35,13 +35,22 @@ class UnsignedTransactionTests extends TestBase {
     super.afterAll()
   }
 
+  private def prepareUser(userName: String): (PrivateKey, String) = {
+    // create user
+    // get testUser certificate and private key
+    val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(userName, organisationId)
+    val privateKey: PrivateKey = testUserIdentity.getPrivateKey
+    val certificatePem: String = TestHelperCrypto.toPemString(testUserIdentity.getCertificate)
+
+    (privateKey, certificatePem)
+  }
+
   "The ConnectionCertificate" when {
     "querying for an unsigned proposal" should {
       "return an unsigned proposal" in {
-        val enrollmentId = "100"
-        val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(enrollmentId, organisationId)
-        val certificate = TestHelperCrypto.toPemString(testUserIdentity.getCertificate)
-        val (approvalResult, proposalBytes) = certificateConnection.getProposalAddCertificate(certificate, organisationId, enrollmentId, certificate)
+        val testUserId = "100"
+        val (privateKey, certificate) = prepareUser(testUserId)
+        val (approvalResult, proposalBytes) = certificateConnection.getProposalAddCertificate(certificate, organisationId, testUserId, certificate)
         val proposal: Proposal = Proposal.parseFrom(proposalBytes)
         val header = proposal.getHeader.toStringUtf8
 
@@ -52,22 +61,27 @@ class UnsignedTransactionTests extends TestBase {
         TestHelper.testProposalPayloadBytesContainsInfo(proposalBytes, Seq(
           "UC4.Certificate",
           "addCertificate",
-          enrollmentId,
+          testUserId,
           certificate
         ))
       }
     }
     "passing a wrongly-signed transaction" should {
       "deny the transaction on the ledger" in {
-        val enrollmentId = "101"
+        val testUserId = "101"
+        val (privateKey, certificate) = prepareUser(testUserId)
+
         val wrongCertificate =
           "-----BEGIN CERTIFICATE-----\nMIICxjCCAm2gAwIBAgIUGJFrzMxyOAdnJErfr+UfDrLDJb4wCgYIKoZIzj0EAwIw\nYDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMREwDwYDVQQDEwhyY2Etb3Jn\nMTAeFw0yMDEwMjAxMDEzMDBaFw0yMTEwMjAxMDE4MDBaMDgxDjAMBgNVBAsTBWFk\nbWluMSYwJAYDVQQDEx1zY2FsYS1yZWdpc3RyYXRpb24tYWRtaW4tb3JnMTBZMBMG\nByqGSM49AgEGCCqGSM49AwEHA0IABLStxuihhyb2XU0wzMhV3Su2Dr7LUI4z/IeL\nzeUDzhcqnZxLDN5w43rV0FXu4yRq0krOaxRhpAY65dmQQ6PRrzujggErMIIBJzAO\nBgNVHQ8BAf8EBAMCA6gwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwG\nA1UdEwEB/wQCMAAwHQYDVR0OBBYEFLAa99vOXhJylch+MQGthFCG/v+RMB8GA1Ud\nIwQYMBaAFBJ7z3hS1NU4HpEaFgyWKir699s5MCgGA1UdEQQhMB+CHXNjYWxhLXJl\nZ2lzdHJhdGlvbi1hZG1pbi1vcmcxMH4GCCoDBAUGBwgBBHJ7ImF0dHJzIjp7ImFk\nbWluIjoidHJ1ZSIsImhmLkFmZmlsaWF0aW9uIjoiIiwiaGYuRW5yb2xsbWVudElE\nIjoic2NhbGEtcmVnaXN0cmF0aW9uLWFkbWluLW9yZzEiLCJoZi5UeXBlIjoiYWRt\naW4ifX0wCgYIKoZIzj0EAwIDRwAwRAIgEjWf7bQyGkHf2bj16MyQ874wCWOb8l2M\n60MlJ4eDgosCIEbD4+stNqZKKsJ+C48IerpOJD3jwkLG+8y7YuxTpx8Z\n-----END CERTIFICATE-----\n"
-        val (approvalResult, proposalBytes) = certificateConnection.getProposalAddCertificate(wrongCertificate, organisationId, enrollmentId, wrongCertificate)
+        val (approvalResult, proposalBytes) = certificateConnection.getProposalUpdateCertificate(wrongCertificate, organisationId, testUserId, wrongCertificate)
         val proposal: Proposal = Proposal.parseFrom(proposalBytes)
 
         // fake signature
-        val signature = ByteString.copyFrom(Base64.getDecoder.decode("MEUCIQD92OsJsVVFqFfifMV14ROiL5Ni/RaOBkR0DqzetvPfkQIgcrgu9vxr5TuZY6lft5adCETaC3CSE8QA+bs9MheeLcI="))
-        val result = intercept[HyperledgerExceptionTrait](certificateConnection.getUnsignedTransaction(proposalBytes, signature.toByteArray))
+        val signature = crypto.sign(privateKey, proposalBytes)
+        // val signature = ByteString.copyFrom(Base64.getDecoder.decode("MEUCIQD92OsJsVVFqFfifMV14ROiL5Ni/RaOBkR0DqzetvPfkQIgcrgu9vxr5TuZY6lft5adCETaC3CSE8QA+bs9MheeLcI="))
+
+        // try use signature
+        val result = intercept[HyperledgerExceptionTrait](certificateConnection.getUnsignedTransaction(proposalBytes, signature))
         result.actionName should be("validatePeerResponses")
       }
     }
@@ -76,20 +90,15 @@ class UnsignedTransactionTests extends TestBase {
   "The ConnectionMatriculation" when {
     "passing a signed transaction" should {
       "submit the approval transaction to the approval contract" in {
-        // create user
-        // get testUser certificate and private key
-        val argEnrollmentId = "frontend-signing-tester"
-        val testAffiliation = organisationId
-        val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(argEnrollmentId, testAffiliation)
-        val privateKey: PrivateKey = testUserIdentity.getPrivateKey
-        val certificate: X509Certificate = testUserIdentity.getCertificate
+        val testUserId = "frontend-signing-tester"
+        val (privateKey, certificate) = prepareUser(testUserId)
 
         // prepare test data
-        val testMatData = TestDataMatriculation.validMatriculationData1(argEnrollmentId)
+        val testMatData = TestDataMatriculation.validMatriculationData1(testUserId)
 
         // get proposal
         val (proposalApprovalResult, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(
-          Identities.toPemString(certificate),
+          certificate,
           jSonMatriculationData = testMatData
         )
         TestHelper.testProposalPayloadBytesContainsInfo(
@@ -112,29 +121,26 @@ class UnsignedTransactionTests extends TestBase {
         val (transactionApprovalResult, transactionResult) = matriculationConnection.submitSignedTransaction(
           transactionBytes, crypto.sign(privateKey, transactionBytes)
         )
-        transactionApprovalResult should include(argEnrollmentId)
+        transactionApprovalResult should include(testUserId)
         transactionApprovalResult should include(username)
         TestHelperStrings.compareJson(testMatData, transactionResult)
 
         // test approvals on ledger
         val getResult = initializeApproval(username).getApprovals("UC4.MatriculationData", "addMatriculationData", testMatData)
-        getResult should include(argEnrollmentId)
+        getResult should include(testUserId)
         getResult should include(username)
       }
       "submit the real transaction to the real contract" in {
-        // create user
-        // get testUser certificate and private key
-        val argEnrollmentId = "frontend-signing-tester2"
-        val testAffiliation = organisationId
-        val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(argEnrollmentId, testAffiliation)
-        val privateKey: PrivateKey = testUserIdentity.getPrivateKey
-        val certificate: X509Certificate = testUserIdentity.getCertificate
+        val testUserId = "frontend-signing-tester2"
+        val (privateKey, certificate) = prepareUser(testUserId)
 
         // prepare test data
-        val testMatData = TestDataMatriculation.validMatriculationData1(argEnrollmentId)
+        val testMatData = TestDataMatriculation.validMatriculationData1(testUserId)
 
         // get proposal
-        val (_, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(Identities.toPemString(certificate), testAffiliation, testMatData)
+        val (_, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(
+          certificate,
+          jSonMatriculationData = testMatData)
         TestHelper.testProposalPayloadBytesContainsInfo(
           proposalBytes,
           Seq("UC4.MatriculationData", "addMatriculationData", testMatData)
@@ -158,52 +164,67 @@ class UnsignedTransactionTests extends TestBase {
         // check real result
         TestHelperStrings.compareJson(testMatData, realTransactionResult)
         // check approvalResult
-        transactionApprovalResult should include(argEnrollmentId)
+        transactionApprovalResult should include(testUserId)
         transactionApprovalResult should include(username)
 
         // test approvals on ledger
         val getResult = initializeApproval(username).getApprovals("UC4.MatriculationData", "addMatriculationData", testMatData)
-        getResult should include(argEnrollmentId)
+        getResult should include(testUserId)
         getResult should include(username)
 
         // test info stored on matriculation ledger
-        val storedMatData = matriculationConnection.getMatriculationData(argEnrollmentId)
+        val storedMatData = matriculationConnection.getMatriculationData(testUserId)
         TestHelperStrings.compareJson(testMatData, storedMatData)
       }
     }
   }
   "PrintTest info " when {
-    "preparing data " should {
-      "not fail 1" in {
-        val enrollmentId = "105"
-        val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(enrollmentId, organisationId)
-        val certificate = TestHelperCrypto.toPemString(testUserIdentity.getCertificate)
-        val inputMatJSon = TestDataMatriculation.validMatriculationData3("500")
+    "preparing data for matriculation " should {
+      "print info for addMatriculationData" in {
+        val testUserId = "frontend-signing-tester-info-addMatriculationData"
+        val (privateKey, certificate) = prepareUser(testUserId)
+        val inputMatJSon = TestDataMatriculation.validMatriculationData3(testUserId)
+
+        // Log proposal
         val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(certificate, organisationId, inputMatJSon)
-        val info = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
-        Logger.debug(s"AddMatriculationDataProposal:: $info")
+        val proposalInfo = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
+        Logger.debug(s"AddMatriculationDataProposal:: $proposalInfo")
+
+        // Log transaction
+        val transactionBytes: Array[Byte] = matriculationConnection.getUnsignedTransaction(proposalBytes, crypto.sign(privateKey, proposalBytes))
+        val transactionInfo = new String(Base64.getEncoder.encode(transactionBytes), StandardCharsets.UTF_8)
+        Logger.debug(s"AddMatriculationDataTransaction:: $transactionInfo")
       }
-      "not fail 2" in {
-        val enrollmentId = "106"
-        val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(enrollmentId, organisationId)
-        val certificate = TestHelperCrypto.toPemString(testUserIdentity.getCertificate)
-        val inputMatJSon = TestDataMatriculation.validMatriculationData4("500")
+      "print info for addMatriculationData" in {
+        val testUserId = "frontend-signing-tester-info-updateMatriculationData"
+        val (privateKey, certificate) = prepareUser(testUserId)
+        val inputMatJSon = TestDataMatriculation.validMatriculationData4(testUserId)
+
+        // Log proposal
         val (approvalResult, proposalBytes) = matriculationConnection.getProposalUpdateMatriculationData(certificate, organisationId, inputMatJSon)
-        val info = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
-        Logger.debug(s"UpdateMatriculationDataProposal:: $info")
+        val proposalInfo = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
+        Logger.debug(s"UpdateMatriculationDataProposal:: $proposalInfo")
+
+        // Log transaction
+        val transactionBytes: Array[Byte] = matriculationConnection.getUnsignedTransaction(proposalBytes, crypto.sign(privateKey, proposalBytes))
+        val transactionInfo = new String(Base64.getEncoder.encode(transactionBytes), StandardCharsets.UTF_8)
+        Logger.debug(s"UpdateMatriculationDataTransaction:: $transactionInfo")
       }
-      "not fail 3" in {
-        val enrollmentId = "107"
-        val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(enrollmentId, organisationId)
-        val certificate = TestHelperCrypto.toPemString(testUserIdentity.getCertificate)
-        val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddEntriesToMatriculationData(
-          certificate,
-          organisationId,
-          "500",
-          TestDataMatriculation.validMatriculationEntry
-        )
-        val info = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
-        Logger.debug(s"AddEntriesToMatriculationDataProposal:: $info")
+      "print info for addMatriculationData" in {
+        val testUserId = "frontend-signing-tester-info-addEntriesToMatriculationData"
+        val (privateKey, certificate) = prepareUser(testUserId)
+        val inputMatJSon = TestDataMatriculation.validMatriculationData4(testUserId)
+
+        // Log proposal
+        val (approvalResult, proposalBytes) = matriculationConnection.getProposalAddEntriesToMatriculationData(certificate, organisationId, testUserId,
+          TestDataMatriculation.validMatriculationEntry)
+        val proposalInfo = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
+        Logger.debug(s"UpdateMatriculationDataProposal:: $proposalInfo")
+
+        // Log transaction
+        val transactionBytes: Array[Byte] = matriculationConnection.getUnsignedTransaction(proposalBytes, crypto.sign(privateKey, proposalBytes))
+        val transactionInfo = new String(Base64.getEncoder.encode(transactionBytes), StandardCharsets.UTF_8)
+        Logger.debug(s"UpdateMatriculationDataTransaction:: $transactionInfo")
       }
     }
   }

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
@@ -2,17 +2,14 @@ package de.upb.cs.uc4.hyperledger.tests
 
 import java.nio.charset.StandardCharsets
 import java.security.PrivateKey
-import java.security.cert.X509Certificate
 import java.util.Base64
 
-import com.google.protobuf.ByteString
 import de.upb.cs.uc4.hyperledger.connections.traits.{ ConnectionCertificateTrait, ConnectionMatriculationTrait }
 import de.upb.cs.uc4.hyperledger.exceptions.traits.HyperledgerExceptionTrait
 import de.upb.cs.uc4.hyperledger.testBase.TestBase
 import de.upb.cs.uc4.hyperledger.tests.testUtil.{ TestDataMatriculation, TestHelper, TestHelperCrypto, TestHelperStrings, TestSetup }
 import de.upb.cs.uc4.hyperledger.utilities.helper.Logger
 import org.hyperledger.fabric.gateway.impl.identity.X509IdentityImpl
-import org.hyperledger.fabric.gateway.Identities
 import org.hyperledger.fabric.protos.peer.ProposalPackage.Proposal
 import org.hyperledger.fabric.sdk.security.CryptoPrimitives
 
@@ -36,7 +33,7 @@ class UnsignedTransactionTests extends TestBase {
   }
 
   private def prepareUser(userName: String): (PrivateKey, String) = {
-    // create user
+    Logger.info(s"prepare User:: $userName")
     // get testUser certificate and private key
     val testUserIdentity: X509IdentityImpl = tryRegisterAndEnrollTestUser(userName, organisationId)
     val privateKey: PrivateKey = testUserIdentity.getPrivateKey
@@ -178,6 +175,7 @@ class UnsignedTransactionTests extends TestBase {
       }
     }
   }
+
   "PrintTest info " when {
     "preparing data for matriculation " should {
       "print info for addMatriculationData" in {
@@ -195,7 +193,7 @@ class UnsignedTransactionTests extends TestBase {
         val transactionInfo = new String(Base64.getEncoder.encode(transactionBytes), StandardCharsets.UTF_8)
         Logger.debug(s"AddMatriculationDataTransaction:: $transactionInfo")
       }
-      "print info for addMatriculationData" in {
+      "print info for updateMatriculationData" in {
         val testUserId = "frontend-signing-tester-info-updateMatriculationData"
         val (privateKey, certificate) = prepareUser(testUserId)
         val inputMatJSon = TestDataMatriculation.validMatriculationData4(testUserId)
@@ -210,7 +208,7 @@ class UnsignedTransactionTests extends TestBase {
         val transactionInfo = new String(Base64.getEncoder.encode(transactionBytes), StandardCharsets.UTF_8)
         Logger.debug(s"UpdateMatriculationDataTransaction:: $transactionInfo")
       }
-      "print info for addMatriculationData" in {
+      "print info for addEntriesToMatriculationData" in {
         val testUserId = "frontend-signing-tester-info-addEntriesToMatriculationData"
         val (privateKey, certificate) = prepareUser(testUserId)
         val inputMatJSon = TestDataMatriculation.validMatriculationData4(testUserId)
@@ -228,4 +226,5 @@ class UnsignedTransactionTests extends TestBase {
       }
     }
   }
+  
 }

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
@@ -250,7 +250,7 @@ class UnsignedTransactionTests extends TestBase {
         val testUserId = "frontend-signing-tester-info-dropAdmission"
         val (privateKey, certificate) = prepareUser(testUserId)
         val inputAdmissionJson = TestDataAdmission.validAdmission(testUserId, "C1", "MatriculationTestModule.1", "2020-12-31T23:59:59")
-        admissionConnection.addAdmission(inputAdmissionJson)
+        // TODO: prepare for validity test: admissionConnection.addAdmission(inputAdmissionJson)
 
         // Log proposal
         val (approvalResult, proposalBytes) = admissionConnection.getProposalDropAdmission(certificate, organisationId, testUserId + ":C1")
@@ -266,7 +266,7 @@ class UnsignedTransactionTests extends TestBase {
         val testUserId = "frontend-signing-tester-info-getAdmission"
         val (privateKey, certificate) = prepareUser(testUserId)
         val inputAdmissionJson = TestDataAdmission.validAdmission(testUserId, "C1", "MatriculationTestModule.1", "2020-12-31T23:59:59")
-        admissionConnection.addAdmission(inputAdmissionJson)
+        // TODO: prepare for validity test: admissionConnection.addAdmission(inputAdmissionJson)
 
         // Log proposal
         val (approvalResult, proposalBytes) = admissionConnection.getProposalGetAdmission(certificate, organisationId, testUserId, "C1", "MatriculationTestModule.1")

--- a/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
+++ b/src/test/scala/de/upb/cs/uc4/hyperledger/tests/UnsignedTransactionTests.scala
@@ -140,7 +140,8 @@ class UnsignedTransactionTests extends TestBase {
         // get proposal
         val (_, proposalBytes) = matriculationConnection.getProposalAddMatriculationData(
           certificate,
-          jSonMatriculationData = testMatData)
+          jSonMatriculationData = testMatData
+        )
         TestHelper.testProposalPayloadBytesContainsInfo(
           proposalBytes,
           Seq("UC4.MatriculationData", "addMatriculationData", testMatData)
@@ -252,7 +253,7 @@ class UnsignedTransactionTests extends TestBase {
         admissionConnection.addAdmission(inputAdmissionJson)
 
         // Log proposal
-        val (approvalResult, proposalBytes) = admissionConnection.getProposalDropAdmission(certificate, organisationId, testUserId+":C1")
+        val (approvalResult, proposalBytes) = admissionConnection.getProposalDropAdmission(certificate, organisationId, testUserId + ":C1")
         val proposalInfo = new String(Base64.getEncoder.encode(proposalBytes), StandardCharsets.UTF_8)
         Logger.debug(s"DropAdmissionProposal:: $proposalInfo")
 
@@ -279,5 +280,5 @@ class UnsignedTransactionTests extends TestBase {
       }
     }
   }
-  
+
 }


### PR DESCRIPTION
### Reason for this PR
- vue needs templates for transactions/proposals for admission handling

### Changes in this PR
- clean Up some tests and logging
- add tests, to print transactions and proposals as Base64 to enable extraction
